### PR TITLE
Add GPL license and player stats

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+GNU GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+
+Copyright 2025 Felix Liu
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/index.html
+++ b/index.html
@@ -1,34 +1,47 @@
+<!-- Copyright 2025 Felix Liu -->
 <!DOCTYPE html>
-<html lang="zh">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Snake Blocking Game / 蛇堵棋</title>
+<title>Snake Blocking Game</title>
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
+<div id="langSwitch">
+  <select id="langSelect">
+    <option value="en">English</option>
+    <option value="zh">中文</option>
+  </select>
+</div>
+<div id="statsBlack" class="stats"></div>
 <canvas id="board" width="600" height="600"></canvas>
 <div id="message"></div>
+<div id="statsWhite" class="stats"></div>
 <div id="controls">
-  <button id="restart">重新开始</button>
-  <button id="cutHead" class="hidden">截断头部</button>
-  <button id="cutTail" class="hidden">截断尾部</button>
+  <button id="restart">Restart</button>
+  <button id="cutHead" class="hidden">Cut Head</button>
+  <button id="cutTail" class="hidden">Cut Tail</button>
 </div>
 <div id="instructions" class="overlay">
-  <h1>Snake Blocking Game / 蛇堵棋</h1>
-  <p>Goal: block both ends of your opponent's snake.<br>目标：堵死对手蛇的两端。</p>
-  <ol>
-    <li>Each player starts from any <strong>star point</strong>. 玩家从任意星位开始。</li>
-    <li>On your turn, place one stone next to either head or tail of your own snake. 每回合只能在自己蛇首尾相邻处下子。</li>
-    <li>An end is <em>blocked</em> when the grid point directly beyond it, along the direction from the previous stone, is off the board or occupied. 若蛇首或蛇尾按照与前一子相同的方向继续前进遭遇棋盘边界或棋子，即判定为堵住。</li>
-    <li>If one end is blocked, you may cut off that blocked part and remove it from the board. 若一端被堵，可截断并清除堵死部分。</li>
-    <li>After placing five stones, you may move diagonally once on your next turn. If unused that turn, the chance is lost. 每下五子后，下一回合可斜向一步，不使用则机会消失。</li>
-    <li>When both ends are blocked, the opponent wins. 若两端被堵，对手获胜。</li>
-  </ol>
-  <p>Valid moves for the current player are highlighted with green dots. 当前可下位置以绿色点标示。</p>
+  <h1 id="title">Snake Blocking Game</h1>
+  <div id="rules"></div>
+  <p id="hint"></p>
   <canvas id="demoBoard" width="200" height="200"></canvas>
-  <button id="startGame">Start / 开始</button>
+  <button id="startGame">Start</button>
 </div>
+<div id="online" class="overlay hidden">
+  <h2 id="onlineTitle">Online Mode</h2>
+  <div>
+    <input id="username" placeholder="Username">
+    <input id="password" type="password" placeholder="Password">
+    <button id="loginBtn">Login</button>
+  </div>
+  <div id="leaderboard"></div>
+  <button id="closeOnline">Close</button>
+</div>
+<button id="onlineBtn">Online</button>
 <script src="script.js" defer></script>
+<!-- Copyright 2025 Felix Liu -->
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,11 +1,16 @@
-body { font-family: sans-serif; text-align: center; }
+body { font-family: sans-serif; text-align: center; position: relative; }
 #board { border: 1px solid #333; display: block; margin: 20px auto; background-color: #f5d6a0; }
 #message { margin-top: 10px; font-weight: bold; }
 #controls { margin-top: 10px; }
 button { margin: 0 5px; }
 .overlay { position: fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.8); color:#fff; display:flex; align-items:center; justify-content:center; flex-direction:column; text-align:left; padding:20px; }
+#langSwitch { position:absolute; top:5px; right:5px; }
 .hidden { display:none; }
 #demoBoard { background:#f5d6a0; border:1px solid #333; margin:20px auto; }
+#online input { margin:5px; }
+.stats { position:absolute; top:50px; width:150px; }
+#statsBlack { left:5px; text-align:right; }
+#statsWhite { right:5px; text-align:left; }
 .stone { width:18px; height:18px; border-radius:50%; position:absolute; }
 .black { background:#000; }
 .white { background:#fff; border:1px solid #000; }


### PR DESCRIPTION
## Summary
- sign code with Felix Liu 2025 GPLv3 and add LICENSE
- display per-player stats and diagonal status next to board
- update language texts for new stats and refresh automatically

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6850722c5e70832c8b9b7131f0515a12