### PR TITLE
Remove replay demo button

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,6 @@
     <canvas id="demo2" width="200" height="200" class="demoBoard"></canvas>
     <p id="caption2" class="demoCaption"></p>
   </div>
-  <button id="replayDemo">Replay Demo</button>
   <button id="startGame">Start</button>
 </div>
 <div id="online" class="overlay hidden">

--- a/script.js
+++ b/script.js
@@ -39,7 +39,6 @@ const texts = {
     moves: 'Moves',
     diagAvail: 'Diagonal',
     cutAvail: 'Cut',
-    replay: 'Replay Demo',
     demoCaptions: [
       [
         'Black starts at a star point.',
@@ -92,7 +91,6 @@ const texts = {
     moves: '计数',
     diagAvail: '斜走',
     cutAvail: '截断',
-    replay: '重播教学',
     demoCaptions: [
       [
         '黑方从星位开始。',
@@ -126,7 +124,6 @@ function applyLang(){
   cutHeadBtn.textContent = t('cutHead');
   cutTailBtn.textContent = t('cutTail');
   document.getElementById('startGame').textContent = t('start');
-  document.getElementById('replayDemo').textContent = t('replay');
   document.getElementById('hint').textContent = t('hint');
   document.getElementById('rules').innerHTML = t('rules');
   document.getElementById('onlineTitle').textContent = t('onlineTitle');
@@ -158,7 +155,6 @@ const occupied = {};
 const messageEl = document.getElementById('message');
 const cutHeadBtn = document.getElementById('cutHead');
 const cutTailBtn = document.getElementById('cutTail');
-const replayBtn = document.getElementById('replayDemo');
 const demoBoards = [
   document.getElementById('demo1'),
   document.getElementById('demo2')
@@ -535,7 +531,6 @@ function cycleDemos(){
 }
 
 document.addEventListener('DOMContentLoaded', ()=>{applyLang(); cycleDemos();});
-replayBtn.onclick = cycleDemos;
 document.getElementById('onlineBtn').onclick = ()=>{
   document.getElementById('online').classList.remove('hidden');
 };

--- a/style.css
+++ b/style.css
@@ -5,7 +5,12 @@ body { font-family: sans-serif; text-align: center; position: relative; }
 #controls { margin-top: 10px; }
 button { margin: 0 5px; }
 .overlay { position: fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.8); color:#fff; display:flex; align-items:center; justify-content:center; flex-direction:column; text-align:left; padding:20px; }
-#langSwitch { position:absolute; top:5px; right:5px; }
+#langSwitch {
+  position: fixed;
+  top: 5px;
+  right: 5px;
+  z-index: 1000;
+}
 .hidden { display:none; }
 .demoFrame { margin:20px 0; }
 .demoBoard { background:#f5d6a0; border:1px solid #333; display:block; margin:0 auto; }


### PR DESCRIPTION
## Summary
- allow language switching while the instructions overlay is visible by repositioning the language switch selector

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850dcaaacfc832ca2925d29c90a9264