### PR TITLE
Add basic AI opponent and per-player cut

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,10 @@
       <p id="caption2" class="demoCaption"></p>
     </div>
   </div>
+  <div id="aiOption">
+    <input type="checkbox" id="aiToggle">
+    <label for="aiToggle" id="aiLabel">AI Opponent</label>
+  </div>
   <button id="startGame">Start</button>
 </div>
 <div id="online" class="overlay hidden">


### PR DESCRIPTION
## Summary
- support playing against an AI opponent
- give each player their own cut instead of sharing one
- update rule descriptions for new cut rule

## Testing
- `node -e "const fs=require('fs'); new Function(fs.readFileSync('script.js','utf8')); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_68518af19d38832cad96f74584c76190