### PR TITLE
Fix language switch demo sync

### DIFF
--- a/script.js
+++ b/script.js
@@ -538,6 +538,7 @@ function runDemo(canvas, captionEl, seq){
   }
   captionEl.textContent = captions[0];
   function step(){
+    if(stopped) return;
     if(idx>=moves.length){
       schedule(()=>{idx=0; placed.length=0; draw(); captionEl.textContent=captions[0]; schedule(step,800);},1000);
       return;


### PR DESCRIPTION
## Summary
- ensure demo step stops when language is switched

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68519671e0a4832cbc6138041b7e3e56