### PR TITLE
Modify rules and AI toggles

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,20 +13,31 @@ const texts = {
     cutTail: 'Cut Tail',
     start: 'Start',
     hint: 'Valid moves for the current player are highlighted with green dots.',
-    rules: `<ol>
+    rulesNormal: `<ol>
       <li>Each player starts from any <strong>star point</strong>.</li>
       <li>On your turn, place one stone next to either head or tail of your snake.</li>
       <li>After every five moves, you may move diagonally once on your next turn; if unused that turn, the chance is lost.</li>
       <li>An end is <em>blocked</em> when the intersection directly forward is off the board or occupied.</li>
-      <li>The head cannot be extended when blocked unless you cut it off. Each player may cut once per game (twice in Long Mode) on either end.</li>
+      <li>The head cannot be extended when blocked unless you cut it off. Each player may cut once per game on either end.</li>
       <li>The tail may optionally be cut from the middle when blocked, removing the blocked half.</li>
       <li>A red box marks each player's last stone.</li>
       <li>If both ends are blocked, that player loses.</li>
-      <li>Long Mode uses a larger board with random obstacles.</li>
+    </ol>`,
+    rulesLong: `<ol>
+      <li>Each player starts from any <strong>star point</strong>.</li>
+      <li>On your turn, place one stone next to either head or tail of your snake.</li>
+      <li>After every five moves, you may move diagonally once on your next turn; if unused that turn, the chance is lost.</li>
+      <li>An end is <em>blocked</em> when the intersection directly forward is off the board or occupied.</li>
+      <li>The head cannot be extended when blocked unless you cut it off. Each player may cut twice per game on either end.</li>
+      <li>The tail may optionally be cut from the middle when blocked, removing the blocked half.</li>
+      <li>A red box marks each player's last stone.</li>
+      <li>If both ends are blocked, that player loses.</li>
+      <li>The board is larger with random obstacles.</li>
     </ol>`,
     aiBlack: 'AI Black',
     aiWhite: 'AI White',
     longMode: 'Long Mode',
+    normalMode: 'Normal Mode',
     black: 'Black',
     white: 'White',
     move: ' to move',
@@ -62,20 +73,31 @@ const texts = {
     cutTail: '截断尾部',
     start: '开始',
     hint: '当前可下位置以绿色点标示。',
-    rules: `<ol>
+    rulesNormal: `<ol>
       <li>双方从任意<strong>星位</strong>开始。</li>
       <li>每回合在自己蛇的头或尾相邻处落子。</li>
       <li>每下五子后，下一回合可斜走一步，若不使用则失效。</li>
       <li>若某端继续前进遇到棋盘外或棋子，则视为被堵。</li>
-      <li>蛇头被堵后除非截断，否则不能再从该端下子；每位玩家每局可截断一次（长局模式下为两次），可选择头或尾。</li>
+      <li>蛇头被堵后除非截断，否则不能再从该端下子；每位玩家每局可截断一次，可选择头或尾。</li>
       <li>蛇尾被堵时可选择从中间截去被堵的一半。</li>
       <li>红框标记双方最后落子的位置。</li>
       <li>若一条蛇两端皆被堵，则其对手获胜。</li>
-      <li>长局模式会使用更大的棋盘，并随机加入障碍。</li>
+    </ol>`,
+    rulesLong: `<ol>
+      <li>双方从任意<strong>星位</strong>开始。</li>
+      <li>每回合在自己蛇的头或尾相邻处落子。</li>
+      <li>每下五子后，下一回合可斜走一步，若不使用则失效。</li>
+      <li>若某端继续前进遇到棋盘外或棋子，则视为被堵。</li>
+      <li>蛇头被堵后除非截断，否则不能再从该端下子；每位玩家每局可截断两次，可选择头或尾。</li>
+      <li>蛇尾被堵时可选择从中间截去被堵的一半。</li>
+      <li>红框标记双方最后落子的位置。</li>
+      <li>若一条蛇两端皆被堵，则其对手获胜。</li>
+      <li>棋盘更大并随机加入障碍。</li>
     </ol>`,
     aiBlack: '黑方电脑',
     aiWhite: '白方电脑',
     longMode: '长局模式',
+    normalMode: '普通模式',
     black: '黑',
     white: '白',
     move: '方行动',
@@ -110,6 +132,11 @@ function t(key){
   return texts[lang][key];
 }
 
+function updateRules(){
+  const rulesEl = document.getElementById('rules');
+  rulesEl.innerHTML = longToggle.checked ? t('rulesLong') : t('rulesNormal');
+}
+
 function applyLang(){
   document.documentElement.lang = lang;
   document.getElementById('title').textContent = t('title');
@@ -119,7 +146,7 @@ function applyLang(){
   cutTailBtn.textContent = t('cutTail');
   document.getElementById('startGame').textContent = t('start');
   document.getElementById('hint').textContent = t('hint');
-  document.getElementById('rules').innerHTML = t('rules');
+  updateRules();
   document.getElementById('aiBlackLabel').textContent = t('aiBlack');
   document.getElementById('aiWhiteLabel').textContent = t('aiWhite');
   document.getElementById('longLabel').textContent = t('longMode');
@@ -147,6 +174,9 @@ const occupied = {};
 const messageEl = document.getElementById('message');
 const cutHeadBtn = document.getElementById('cutHead');
 const cutTailBtn = document.getElementById('cutTail');
+const aiBlackToggle = document.getElementById('aiBlackToggle');
+const aiWhiteToggle = document.getElementById('aiWhiteToggle');
+const longToggle = document.getElementById('longToggle');
 const demoBoards = [
   document.getElementById('demo1'),
   document.getElementById('demo2')
@@ -168,6 +198,18 @@ let aiWhite = false;
 let longMode = false;
 const obstacles = [];
 const items = [];
+
+function updateAiToggles(){
+  if(!longToggle.checked){
+    if(aiBlackToggle.checked && aiWhiteToggle.checked){
+      aiWhiteToggle.checked = false;
+    }
+  }
+}
+
+aiBlackToggle.onchange = updateAiToggles;
+aiWhiteToggle.onchange = updateAiToggles;
+longToggle.onchange = ()=>{ updateRules(); updateAiToggles(); };
 
 function setupCanvas(c,w,h){
   const dpr = window.devicePixelRatio || 1;
@@ -575,9 +617,9 @@ function checkWin(){
 document.getElementById('restart').onclick = ()=>location.reload();
 
 document.getElementById('startGame').onclick = ()=>{
-  aiBlack = document.getElementById('aiBlackToggle').checked;
-  aiWhite = document.getElementById('aiWhiteToggle').checked;
-  longMode = document.getElementById('longToggle').checked;
+  aiBlack = aiBlackToggle.checked;
+  aiWhite = aiWhiteToggle.checked;
+  longMode = longToggle.checked;
   boardSize = longMode ? 27 : 19;
   cutAvailable.black = longMode ? 2 : 1;
   cutAvailable.white = longMode ? 2 : 1;
@@ -696,4 +738,9 @@ function cycleDemos(){
   });
 }
 
-document.addEventListener('DOMContentLoaded', ()=>{applyLang(); cycleDemos();});
+document.addEventListener('DOMContentLoaded', ()=>{
+  applyLang();
+  updateRules();
+  updateAiToggles();
+  cycleDemos();
+});


### PR DESCRIPTION
## Summary
- split rule text for normal/long mode
- show the correct rules based on selected mode
- restrict normal mode to only one AI

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6851b7acd208832c81aa09c087027334